### PR TITLE
 Replace internal ALB with service discovery

### DIFF
--- a/mu.yml
+++ b/mu.yml
@@ -3,14 +3,3 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
-  priority: 2
-  pathPatterns:
-  - /crystal
-  networkMode: awsvpc
-parameters:
-  '${env:MU_NAMESPACE}-service-ecsdemo-crystal-acceptance':
-    ElbHttpListenerArn:
-        ${env:MU_NAMESPACE}-loadbalancer-acceptance-BackendLBHttpListenerArn
-  '${env:MU_NAMESPACE}-service-ecsdemo-crystal-production':
-    ElbHttpListenerArn:
-        ${env:MU_NAMESPACE}-loadbalancer-production-BackendLBHttpListenerArn

--- a/mu.yml
+++ b/mu.yml
@@ -3,4 +3,4 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
-  discoveryTTL: 0
+  discoveryTTL: 5

--- a/mu.yml
+++ b/mu.yml
@@ -3,3 +3,4 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
+  discoveryTTL: 0


### PR DESCRIPTION
Leverage new feature of mu 1.5.1 to support AWS Service Discovery instead of using an internal ALB